### PR TITLE
Remove unused imports and use .ok() to make `cargo check` pass.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn render_articles(articles: &Vec<Article>) {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    dotenv();
+    dotenv().ok();
 
     let api_key = std::env::var("API_KEY")?;
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
-use crossterm::style::Color::{AnsiValue, Green, Rgb, Yellow};
-use termimad::{rgb, MadSkin, StyledChar};
+use crossterm::style::Color::{Rgb, Yellow};
+use termimad::{MadSkin, StyledChar};
 
 pub fn default() -> MadSkin {
     let mut skin = MadSkin::default();


### PR DESCRIPTION
`cargo check` was giving some warnings. This fixes the warnings.